### PR TITLE
fix import of pandas InvalidIndexError

### DIFF
--- a/limix/_data/_conform.py
+++ b/limix/_data/_conform.py
@@ -246,7 +246,7 @@ def _check_uniqueness(data, dims):
 
 
 def _match_samples(data, dims):
-    from pandas.core.index import InvalidIndexError
+    from pandas.core.indexes.api import InvalidIndexError
 
     inc_msg = "The provided trait and {} arrays are sample-wise incompatible."
 


### PR DESCRIPTION
Hi,

It seems that pandas.core.index has been removed in pandas 1.1.0, meaning that currently limix only works with pandas <= 1.0.5