### PR TITLE
issue fix for automatic documentation

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,3 +2,4 @@ ipython>=7.6.1
 sphinx>=2.1.2
 sphinx_rtd_theme>=0.4.3
 sphinxcontrib-programoutput>=0.14
+click<=8.0.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,4 +2,4 @@ ipython>=7.6.1
 sphinx>=2.1.2
 sphinx_rtd_theme>=0.4.3
 sphinxcontrib-programoutput>=0.14
-click<=8.0.0
+click<8.0.0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,5 +2,5 @@ build:
     image: latest
 
 python:
-    version: 3.6
+    version: 3.7
     setup_py_install: true


### PR DESCRIPTION
Hi Danilo,

It looks changing these two requirements can fix the issue for the documentation auto generation:
* python=3.7
* click<8.0.0

Huang